### PR TITLE
Update linux.md

### DIFF
--- a/docs/stack/get-started/install/linux.md
+++ b/docs/stack/get-started/install/linux.md
@@ -8,7 +8,7 @@ weight: 1
 
 
 ### From the official Debian/Ubuntu APT Repository
-You can install recent stable versions of Redis Stack from the official packages.redis.io APT repository. The repository currently supports Ubuntu Xenial (16.04), Ubuntu Bionic (18.04), and Ubuntu Focal (20.04). Add the repository to the apt index, update it and install:
+You can install recent stable versions of Redis Stack from the official packages.redis.io APT repository. The repository currently supports Ubuntu Xenial (16.04), Ubuntu Bionic (18.04), and Ubuntu Focal (20.04) on x86 processors. Add the repository to the apt index, update it and install:
 
 {{< highlight bash >}}
 curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg


### PR DESCRIPTION
Update documentation to specify x86; running the same commands on ARM (Graviton2) doesn't work - there's no redis-stack-server install candidate.