### PR TITLE
Enabling Netlify previews

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pytoml = "==0.1.21"
+PyYAML = "==6.0"
+railroad-diagrams = "==1.1.1"
+requests = "==2.27.1"
+semver = "==2.13.0"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/netlify.bash
+++ b/netlify.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+rm -rf redis-stack-website
+git clone --recurse-submodules https://$PRIVATE_ACCESS_TOKEN@github.com/redis-stack/redis-stack-website
+cd redis-stack-website
+npm install autoprefixer
+REDIS_STACK_DOCS_SHA=$COMMIT_REF REDIS_STACK_DOCS_REMOTE=$REPOSITORY_URL make netlify


### PR DESCRIPTION
This will enable netlify previews for PRs to the redis-stack-docs repo. Note, netlify still needs to be properly configured (needs another pr in website repo before this will work correctly).