### PR TITLE
Fix typo in article "Run Redis Stack on Docker"

### DIFF
--- a/docs/stack/get-started/install/docker.md
+++ b/docs/stack/get-started/install/docker.md
@@ -21,7 +21,7 @@ To start Redis Stack server using the `redis-stack-server` image, run the follow
 docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest
 {{< / highlight >}}
 
-You can that the Redis Stack server database to your [RedisInsight]() desktop application.
+You can connect the Redis Stack server database to your [RedisInsight]() desktop application.
 
 ### redis/redis-stack
 To start Redis Stack developer container using the `redis-stack` image, run the following command in your terminal:


### PR DESCRIPTION
The sentence

> You can that the Redis Stack server database to your [RedisInsight]() desktop application.

doesn't make sense.

I propose to change `that` to `connect`. Happy to adjust this to something even better.