### PR TITLE
Fixes link to RSALv2

### DIFF
--- a/docs/stack/about/index.md
+++ b/docs/stack/about/index.md
@@ -73,7 +73,7 @@ mapping libraries also support Redis Stack: [Redis OM .NET](/docs/stack/get-star
 
 Redis Stack is made up of several components, licensed as follows:
 
-* Redis Stack Server, which combines open source Redis with RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom, is dual-licensed under the Redis Source Available License ([RSALv2]((/docs/stack/license/)) and the [Server Side Public License](https://en.wikipedia.org/wiki/Server_Side_Public_License) (SSPL). A breakdown of licensing by Stack component versions is shown in the table below. For more information about Redis licensing, see [Licenses](https://redis.com/legal/licenses/).
+* Redis Stack Server, which combines open source Redis with RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom, is dual-licensed under the Redis Source Available License ([RSALv2](/docs/stack/license/)) and the [Server Side Public License](https://en.wikipedia.org/wiki/Server_Side_Public_License) (SSPL). A breakdown of licensing by Stack component versions is shown in the table below. For more information about Redis licensing, see [Licenses](https://redis.com/legal/licenses/).
 
 * RedisInsight is licensed under the SSPL.
 


### PR DESCRIPTION
Currently, the link to RSALv2 redirects to a dead link on [stack page](https://redis.io/docs/stack/about/#redis-stack-license).

This PR attempts to fix that.