### PR TITLE
Update docker stack container name

### DIFF
--- a/docs/stack/get-started/install/docker.md
+++ b/docs/stack/get-started/install/docker.md
@@ -38,7 +38,7 @@ You can then connect to the server using `redis-cli`, just as you connect to any
 If you don’t have `redis-cli` installed locally, you can run it from the Docker container:
 
 {{< highlight bash >}}
-$ docker exec -it redis-stack redis-cli
+$ docker exec -it redis-stack-server redis-cli
 {{< / highlight >}}
 
 ## Configuration


### PR DESCRIPTION
There is a minor typo on the instruction to execute docker stack server, and therefore, this change is addressing that.