### PR TITLE
Add coredis to clients supporting redis stack

### DIFF
--- a/docs/stack/get-started/clients/_index.md
+++ b/docs/stack/get-started/clients/_index.md
@@ -16,6 +16,7 @@ The following core client libraries support Redis Stack:
 * [Jedis](https://github.com/redis/jedis) >= 4.0
 * [node-redis](https://github.com/redis/node-redis) >= 4.0
 * [redis-py](https://github.com/redis/redis-py/) >= 4.0
+* [coredis](https://github.com/alisaifee/coredis/) >= 4.12
 
 ## High-level client libraries
 


### PR DESCRIPTION
# Description
As of version [4.12](https://coredis.readthedocs.io/en/stable/release_notes.html#v4-12-0) [coredis](https://github.com/alisaifee/coredis) has command level support for the following modules from redis stack:
- [RedisJSON](https://coredis.readthedocs.io/en/stable/handbook/modules.html#redisjson)
- [RedisBloom](https://coredis.readthedocs.io/en/stable/handbook/modules.html#redisbloom)
- [RedisGraph](https://coredis.readthedocs.io/en/stable/handbook/modules.html#redisgraph)
- [RediSearch](https://coredis.readthedocs.io/en/stable/handbook/modules.html#redisearch)
- [RedisTimeSeries](https://coredis.readthedocs.io/en/stable/handbook/modules.html#redistimeseries)