### PR TITLE
Make sure /usr/share/keyrings/redis-archive-keyring.gpg is world readable

### DIFF
--- a/docs/stack/get-started/install/linux.md
+++ b/docs/stack/get-started/install/linux.md
@@ -12,6 +12,7 @@ You can install recent stable versions of Redis Stack from the official packages
 
 {{< highlight bash >}}
 curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 sudo apt-get update
 sudo apt-get install redis-stack-server


### PR DESCRIPTION
Had "NO_PUBKEY 5F4349D6BF53AA0C" issues because the file was only 640 (Ubuntu Focal)