### PR TITLE
Binary update instructions

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -221,6 +221,7 @@ keyName
 keyrings
 lastName
 latencies
+libssl-dev
 linkTitle
 loadTestData
 localhost

--- a/docs/stack/get-started/install-stack/binaries.md
+++ b/docs/stack/get-started/install-stack/binaries.md
@@ -10,6 +10,12 @@ aliases:
 
 ## Start Redis Stack Server
 
+Install the openssl libraries for your platform. For example, on a Debian or Ubuntu instance run:
+
+{{< highlight bash >}}
+sudo apt install libssl-dev
+{{< / highlight >}}
+
 After untarring or unzipping your redis-stack-server download, you can start Redis Stack Server as follows:
 
 {{< highlight bash >}}


### PR DESCRIPTION
In the download case, due to a dependency in an underlying module, we need to instruct users to install the ssl libraries. This is not the case in packages, because they declare their own dependencies.