### PR TITLE
Changed colon for comma for more clarity.

### DIFF
--- a/docs/stack/get-started/om-clients/stack-python.md
+++ b/docs/stack/get-started/om-clients/stack-python.md
@@ -35,8 +35,8 @@ Our entity is a Person, with the following JSON representation:
   },
   "personal_statement": "A string, free text personal statement",
   "skills": [
-    "A string: a skill the person has",
-    "A string: another still that the person has"
+    "A string, a skill the person has",
+    "A string, another still that the person has"
   ]
 }
 ```


### PR DESCRIPTION
I've replaced the colon in the two "skills" list elements for commas. This fits the format of other strings in this examples, and removes confusion as this is not supposed to represent a mapping of elements, but a description of the string.