### PR TITLE
fix: Remove extra port -p 6379:6379 in redis/redis-stack

### DIFF
--- a/docs/stack/install/install-stack/docker.md
+++ b/docs/stack/install/install-stack/docker.md
@@ -29,7 +29,7 @@ docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:la
 To start a Redis Stack container using the `redis-stack` image, run the following command in your terminal:
 
 {{< highlight bash >}}
-docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
+docker run -d --name redis-stack -p 8001:8001 redis/redis-stack:latest
 {{< / highlight >}}
 
 The `docker run` command above also exposes RedisInsight on port 8001. You can use RedisInsight by pointing your browser to `localhost:8001`.


### PR DESCRIPTION
Update 
```
docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
```
to 
```
docker run -d --name redis-stack -p 8001:8001 redis/redis-stack:latest
```